### PR TITLE
Fixes #8

### DIFF
--- a/src/prop-bridge.tsx
+++ b/src/prop-bridge.tsx
@@ -49,7 +49,7 @@ export const getPropsFromNode = (node: HTMLElement) => {
     {}
   );
 
-  const children = Array.from(node.children).map((e) => e.cloneNode(true));
+  const children = Array.from(node.childNodes).map((e) => e.cloneNode(true));
   mappedProps.children = <ReactDomChild>{children}</ReactDomChild>;
   return mappedProps;
 };


### PR DESCRIPTION
Pretty simple change.

Using the same example in the issue: #8

`Element.children` returns `Node []` for `<wc-button>Button</wc-button>`
`Element.childNodes` returns `Node [text]` for `<wc-button>Button</wc-button>`